### PR TITLE
30_rockchip_ebc.rules: set permissions, generically to all parameters

### DIFF
--- a/overlays/udev/30_rockchip_ebc.rules
+++ b/overlays/udev/30_rockchip_ebc.rules
@@ -4,7 +4,7 @@
 # default_waveform  diff_mode  direct_mode  panel_reflection  skip_reset
 #KERNELS=="rockchip_ebc", RUN+="/bin/chgrp video /sys/module/rockchip_ebc/parameters/default_waveform", RUN+="/bin/chmod g+w /sys/module/rockchip_ebc/parameters/default_waveform", RUN+="/bin/chgrp video /sys/module/rockchip_ebc/parameters/diff_mode", RUN+="/bin/chmod g+w /sys/module/rockchip_ebc/parameters/diff_mode"
 
-SUBSYSTEM=="module", KERNEL=="rockchip_ebc", RUN+="/bin/chgrp video /sys/module/%k/parameters/no_off_screen /sys/module/%k/parameters/auto_refresh /sys/module/%k/parameters/prepare_prev_before_a2 /sys/module/%k/parameters/bw_dither_invert /sys/module/%k/parameters/bw_threshold /sys/module/%k/parameters/bw_mode /sys/module/%k/parameters/diff_mode /sys/module/%k/parameters/split_area_limit /sys/module/%k/parameters/default_waveform", RUN+="/bin/chmod g+w /sys/module/%k/parameters/prepare_prev_before_a2 /sys/module/%k/parameters/bw_dither_invert /sys/module/%k/parameters/bw_threshold /sys/module/%k/parameters/bw_mode /sys/module/%k/parameters/default_waveform  /sys/module/%k/parameters/diff_mode /sys/module/%k/parameters/auto_refresh /sys/module/%k/parameters/split_area_limit /sys/module/%k/parameters/no_off_screen"
+ACTION=="add" SUBSYSTEM=="module", KERNEL=="rockchip_ebc", RUN+="/bin/find /sys/module/%k/parameters/ -type f -exec /bin/chgrp video {} +", RUN+="/bin/find /sys/module/%k/parameters/ -group video -exec /bin/chmod g+w {} +"
 
 DRIVER=="rockchip-ebc", RUN+="/bin/chgrp video /sys/%p/power/control", RUN+="/bin/chmod g+w /sys/%p/power/control"
 


### PR DESCRIPTION
Instead of specifing each filename, use `/bin/find` to get all the parameters of the module and the `-exec` subcommand to call `chgrp` and `chmod`.
Add the condition `Action=="add"` to the set permissions rule.