### PR TITLE
overlays: default: Fix keyboard layout by setting it to 'us'

### DIFF
--- a/overlays/default/keyboard
+++ b/overlays/default/keyboard
@@ -3,7 +3,7 @@
 # Consult the keyboard(5) manual page.
 
 XKBMODEL="pc105"
-XKBLAYOUT="en"
+XKBLAYOUT="us"
 XKBVARIANT=""
 XKBOPTIONS=""
 


### PR DESCRIPTION
AFAIK, there is no 'en' keyboard layout, but the most common one is 'us', so change it to that. This fixes the following error:

```sh
console-setup.sh[400]: /usr/bin/ckbcomp: Can not find file "symbols/en" in any known directory
```

And is the reason why the `console-setup.service` is currently failing.