### PR TITLE
Look the battery up through /sys/class/power_supply instead of globbing the platform path

### DIFF
--- a/overlays/systemd-sleep/pn_record_power_usage.py
+++ b/overlays/systemd-sleep/pn_record_power_usage.py
@@ -5,7 +5,6 @@ Record power usage during sleep
 Place in: /lib/systemd/systemd-sleep
 
 """
-import glob
 import os
 import sys
 import time
@@ -16,19 +15,22 @@ if len(sys.argv) < 3:
 
 persistent_file = '/root/energy_use.dat'
 tmp_file = '/tmp/tmp_charge.dat'
-bat_dir_old = ''.join((
-    '/sys/bus/i2c/devices/0-0020/rk817-charger/power_supply/rk817-battery/'
-))
-charger_dir = glob.glob('/sys/bus/i2c/devices/0-0020/rk817-charger.*.auto')
-assert len(charger_dir) == 1
-bat_dir_new = charger_dir[0] + '/power_supply/rk817-battery'
-assert os.path.isdir(bat_dir_new)
-
-bat_dirs = (bat_dir_old, bat_dir_new)
+# /sys/class/power_supply is the stable interface: the kernel points this
+# symlink at the battery wherever the driver instance happens to land, so
+# there is no platform instance number to glob for.
+bat_dirs = (
+    '/sys/class/power_supply/rk817-battery',
+    '/sys/bus/i2c/devices/0-0020/rk817-charger/power_supply/rk817-battery',
+)
+bat_dir = None
 for directory in bat_dirs:
     if os.path.isdir(directory):
         bat_dir = directory + os.sep
         break
+if bat_dir is None:
+    # No battery to read: nothing to record. Leaving quietly beats raising
+    # on every single suspend.
+    exit()
 
 charge_full_file = bat_dir + 'charge_full'
 charge_full_mah = int(open(charge_full_file, 'r').readline().strip())


### PR DESCRIPTION
`pn_record_power_usage.py` locates the battery by globbing for the charger's platform instance directory, then asserts that exactly one match exists and that it contains a battery. Both assertions run at import time, inside a `system-sleep` hook, on every suspend.

`/sys/class/power_supply/rk817-battery` is the stable interface for this: the kernel keeps that symlink pointing at the battery regardless of which platform instance the driver lands on — nothing to glob, no instance number to track.

This PR looks the battery up there first (keeping the older bus path as a fallback), drops the two `assert`s and the `glob` import, and exits quietly when no battery is found instead of raising.

### Why the failure mode matters

On the older image still shipping on our unit, the same lookup was two hard-coded paths, one of them containing `rk817-charger.6.auto`. This unit enumerates as `.7.auto`, so neither path existed, the loop never assigned `bat_dir`, and the script died with `NameError: name 'bat_dir' is not defined` on *every* suspend — `/root/energy_use.dat` had never recorded a single line since the machine was set up.

The glob fixed that specific case. The shape is still there, though: if the lookup ever misses, the hook raises on every suspend rather than skipping one measurement. Since this script is the only instrumentation for sleep power draw, a silent absence of data is exactly the failure you do not want it to have.

### Tested

On a PineNote Community Edition, with this version installed at `/usr/lib/systemd/system-sleep/pn_record_power_usage.py`: a full `systemctl suspend` / resume cycle appends a row to `/root/energy_use.dat`, and the journal shows the `pre suspend` / `post suspend` hooks running with no exception.

For what it is worth, the numbers this instrument produced once it started working were the point of fixing it — idle-suspend on battery measures ~23–32 mA (~5–7 days from a full charge), against a device that was otherwise flat in under a day.
