### PR TITLE
gnome: install iio-sensor-proxy so Auto Rotate works

### DIFF
--- a/07_gnome.yaml
+++ b/07_gnome.yaml
@@ -19,6 +19,7 @@ actions:
       - portfolio-filemanager
       - vlc
       - power-profiles-daemon
+      - iio-sensor-proxy
 
   - action: apt
     recommends: false


### PR DESCRIPTION
The Auto Rotate switch in Quick Settings is greyed out on a fresh image: nothing
exposes the accelerometer on D-Bus, so GNOME sees no sensor. This adds the one
package that connects them.

It is not an omission so much as a side effect of the build flags. Both
`gnome-shell` and `gnome-settings-daemon` list `iio-sensor-proxy` under
Recommends, and `07_gnome.yaml` builds with `recommends: false`:

```
$ apt-cache show gnome-settings-daemon | grep ^Recommends
Recommends: iio-sensor-proxy, pipewire-audio, pkexec, x11-xserver-utils
```

`power-profiles-daemon`, three lines above in the same list, comes off that same
gnome-shell Recommends line and is already restored by hand — this is the other
one.

Tested on a PineNote v1.2 (kernel 6.12.11, trixie):

```
$ gdbus call --system --dest net.hadess.SensorProxy \
      --object-path /net/hadess/SensorProxy \
      --method org.freedesktop.DBus.Properties.GetAll net.hadess.SensorProxy
({'HasAccelerometer': <true>, 'AccelerometerOrientation': <'normal'>, ...},)
```

Refs #45, where auto-rotation was asked for so the sensor could be tested at all.

### One caveat, which is not this repository's bug

With the proxy installed the switch works, but the four orientations collapse
into two, both landscape. That is a systemd hwdb collision, not an image
problem: `60-sensor.hwdb` carries an `ACCEL_MOUNT_MATRIX` labelled for the
PineTab2, keyed on a modalias that names the chip (`silan,sc7a20`) and not the
machine. The PineNote uses the same chip mounted differently, and its device
tree already supplies the correct matrix, which the hwdb entry then overrides.

Reported upstream as systemd#43321; the maintainer's answer was to drop the
entry, and a revert is on its way there. Until it lands, a udev rule filed after
the `60-` one reasserts the device-tree value:

```
SUBSYSTEM=="iio", KERNEL=="iio:device*", ATTR{name}=="sc7a20", \
  ENV{ACCEL_MOUNT_MATRIX}="-1, 0, 0; 0, 1, 0; 0, 0, 1"
```

I have deliberately left that rule out of this PR — it becomes dead weight once
the systemd revert ships, and this change is worth having either way. Happy to
add it if you would rather the image not wait.
